### PR TITLE
Add primary region to fly.toml

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,6 +1,7 @@
 app = "recipe-saver-0dec"
 kill_signal = "SIGINT"
 kill_timeout = 5
+primary_region = "ord"
 processes = [ ]
 
 [env]


### PR DESCRIPTION
The purpose of the primary region is to assist with the deployment step. See this thread for more: https://community.fly.io/t/error-error-creating-a-new-machine-machine-failed-to-launch-vm-mounts-source-volume-is-in-the-wrong-region-sin-iad/11873/10