### PR TITLE
Revamp NYTimes Parsing + others

### DIFF
--- a/app/comments/comment.server.ts
+++ b/app/comments/comment.server.ts
@@ -59,10 +59,7 @@ export const getComments = async ({
   invariant(associatedId, "associatedId not found");
   switch (commentType) {
     case "recipe": {
-      return await getRecipeComments({
-        id: associatedId,
-        requestingUser: { id: userId },
-      });
+      return await getRecipeComments(associatedId, userId);
     }
     default:
       throw new Response(`Unsupported comment type: ${commentType}`, { status: 400 });

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -57,7 +57,7 @@ const StandardHeader = ({ title, className }: Readonly<HeaderProps>) => {
         <div className="hidden md:flex">
           {user ? (
             <Link
-              to="/recipes/new?submissionStyle=create-manual"
+              to="/recipes/new?submissionStyle=create-from-url"
               className="
       px-4 py-2 rounded
       bg-blue-500 text-white text-xl

--- a/app/components/truncate-text.tsx
+++ b/app/components/truncate-text.tsx
@@ -1,7 +1,7 @@
 export default function TruncateText({ children}: React.PropsWithChildren<unknown>) {
   return (
-    <div className="max-w-full text-ellipsis overflow-hidden whitespace-nowrap">
+    <span className="max-w-full text-ellipsis overflow-hidden whitespace-nowrap">
       {children}
-    </div>
+    </span>
   );
 }

--- a/app/recipes/recipe-loader.ts
+++ b/app/recipes/recipe-loader.ts
@@ -1,7 +1,7 @@
 import type { LoaderFunctionArgs } from "@remix-run/node";
 import invariant from "tiny-invariant";
 
-import { RecipeUserArgs, getRecipeWithIngredients } from "~/recipes/recipe.server";
+import { getRecipeWithIngredients } from "~/recipes/recipe.server";
 import { getUser } from "~/session.server";
 import { getCookCounts } from "~/users/user.recipe.server";
 import { isNotPlaceholderIngredient, parsePreparationSteps } from "~/utils";
@@ -10,24 +10,20 @@ import { isNotPlaceholderIngredient, parsePreparationSteps } from "~/utils";
 export async function loadSingleRecipe({ params, request, mode }: Pick<LoaderFunctionArgs, "params" | "request"> & { mode: 'edit' | 'view';}) {
   invariant(params.recipeId, "recipeId not found");
   const user = await getUser(request);
+  const userId = user?.id
 
-  const args: RecipeUserArgs = { id: params.recipeId };
-  if (user) {
-    args['requestingUser'] = user
-  }
-
-  const rawRecipe = await getRecipeWithIngredients(args);
+  const rawRecipe = await getRecipeWithIngredients(params.recipeId, userId);
   if (!rawRecipe) {
     throw new Response("Not Found", { status: 404 });
   }
-  if (rawRecipe.isPrivate && rawRecipe.submittedBy !== user?.id) {
+  if (rawRecipe.isPrivate && rawRecipe.submittedBy !== userId) {
     throw new Response("Not Found", { status: 404 });
   }
-  if (mode == 'edit' && rawRecipe.submittedBy !== user?.id) {
+  if (mode == 'edit' && rawRecipe.submittedBy !== userId) {
     throw new Response("Cannot edit a recipe owned by another user", { status: 401 });
   }
 
-  const cookCounts = await getCookCounts(params.recipeId, user?.id);
+  const cookCounts = await getCookCounts(params.recipeId, userId);
 
   const recipe = {
     ...rawRecipe,

--- a/app/recipes/recipe.parse.utils.test.ts
+++ b/app/recipes/recipe.parse.utils.test.ts
@@ -1,0 +1,289 @@
+import { _testing, parseIngredientsList } from "./recipe.parse.utils";
+const { parseIngredientQuantity, parseIngredientNotes, parseIngredientUnit, parseIngredientComponents } = _testing;
+describe("RecipeParseUtils", () => {
+
+  describe("parseIngredientQuantity", () => {
+    const testCases = [
+      { raw: "1", quantity: "1" },
+      { raw: "1/2", quantity: "1/2" },
+      { raw: "1 1/2", quantity: "1 1/2" },
+      { raw: "1 1/2 to 2 1/2", quantity: "1 1/2 to 2 1/2" },
+      { raw: "1/2 - 3/4", quantity: "1/2 - 3/4" },
+      { raw: "1/2 to 3/4", quantity: "1/2 to 3/4" },
+      { raw: "2 - 3 and then other words", quantity: "2 - 3" },
+      { raw: "2 to 3 and then other words", quantity: "2 to 3" },
+      { raw: "1/2 (and 1.5 here)", quantity: "1/2" },
+    ]
+    testCases.forEach(({ raw, quantity }) => {
+      it(`parses ${raw}`, () => {
+        const parsed = parseIngredientQuantity(raw)
+        expect(parsed).toEqual(quantity);
+      });
+    })
+    const unhandledCases = [
+      // We do not currently match fractions to integers
+      // We only support integers to integers and fractions to fractions
+      { raw: "1 to 2.5", quantity: "1 to 2.5", expect: "1 to 2" },
+      { raw: "1 1/2 to 2", quantity: "1 1/2 to 2", expect: "1 1/2" },
+      { raw: "1 1/2 - 2", quantity: "1 1/2 - 2", expect: "1 1/2" },
+    ]
+    unhandledCases.forEach(({ raw, quantity, expect: expected }) => {
+      it(`does not correctly parse ${raw}`, () => {
+        const parsed = parseIngredientQuantity(raw)
+        expect(parsed).toEqual(expected);
+        expect(parsed).not.toEqual(quantity);
+      });
+    })
+  })
+
+  describe("parseIngredientnote", () => {
+    const testCases = [
+      { raw: "1/2 (and 1.5 here)", note: "and 1.5 here" },
+      { raw: "1/2 (and 1.5 here, and 2.5 here)", note: "and 1.5 here, and 2.5 here" },
+      { raw: "1/2 (and 1.5 here), and 2.5 here, (3.5 here), and 4.5 here)", note: "and 1.5 here; 3.5 here" },
+    ]
+    testCases.forEach(({ raw, note }) => {
+      it(`parses ${raw}`, () => {
+        const parsed = parseIngredientNotes(raw)
+        expect(parsed).toEqual(note);
+      });
+    })
+  })
+
+  describe("parseIngredientUnit", () => {
+    const testCases = [
+      { raw: "3 tablespoons neutral oil, such as sunflower or canola", unit: "tablespoons", },
+      { raw: "1 large onion, chopped", unit: "whole", },
+      { raw: "2 jalapeños, seeded or not, thinly sliced", unit: "whole", },
+      { raw: "1 bay leaf", unit: "whole", },
+      { raw: "1 knob ginger (about 1 inch), minced", unit: "knob", },
+      { raw: "4 garlic cloves, minced", unit: "cloves", },
+      { raw: "1 1/2 teaspoons garam masala", unit: "teaspoons", },
+      { raw: "1 teaspoon ground cumin", unit: "teaspoon", },
+      { raw: "1/2 teaspoon ground turmeric", unit: "teaspoon", },
+      { raw: "2 (15-ounce) cans chickpeas, rinsed", unit: "cans", },
+      { raw: "1 (13.5-ounce) can coconut milk (do not use light coconut milk)", unit: "can", },
+      { raw: "1 (13.5-ounce) can pumpkin purée", unit: "can", },
+      { raw: "1 1/2 teaspoons fine sea salt, more as needed", unit: "teaspoons", },
+      { raw: "3/4 cup chopped cilantro, more for serving", unit: "cup", },
+      { raw: "2 to 3 tablespoons fresh lime juice, plus wedges for serving", unit: "tablespoons", },
+      { raw: "Cooked rice or couscous, for serving (optional)", unit: "whole", },
+    ]
+    testCases.forEach(({ raw, unit }) => {
+      it(`parses ${raw}`, () => {
+        const parsed = parseIngredientUnit(raw)
+        expect(parsed).toEqual(unit);
+      });
+    })
+  })
+
+
+
+  describe("parseIngredients", () => {
+    const testCases = [
+      {
+        raw: "3 tablespoons neutral oil, such as sunflower or canola",
+        ingredient: "neutral oil, such as sunflower or canola"
+      },
+      {
+        raw: "1 large onion, chopped",
+        ingredient: "large onion, chopped"
+      },
+      {
+        raw: "2 jalapeños, seeded or not, thinly sliced",
+        ingredient: "jalapeños, seeded or not, thinly sliced"
+      },
+      {
+        raw: "1 bay leaf",
+        ingredient: "bay leaf"
+      },
+      {
+        raw: "1 knob ginger (about 1 inch), minced",
+        ingredient: "ginger, minced",
+      },
+      {
+        raw: "4 garlic cloves, minced",
+        ingredient: "garlic, minced"
+      },
+      {
+        raw: "1 1/2 teaspoons garam masala",
+        ingredient: "garam masala"
+      },
+      {
+        raw: "1 teaspoon ground cumin",
+        ingredient: "ground cumin"
+
+      },
+      {
+        raw: "1/2 teaspoon ground turmeric",
+        ingredient: "ground turmeric"
+
+      },
+      {
+        raw: "2 (15-ounce) cans chickpeas, rinsed",
+        ingredient: "chickpeas, rinsed",
+      },
+      {
+        raw: "1 (13.5-ounce) can coconut milk (do not use light coconut milk)",
+        ingredient: "coconut milk",
+      },
+      {
+        raw: "1 (13.5-ounce) can pumpkin purée",
+        ingredient: "pumpkin purée",
+      },
+      {
+        raw: "1 1/2 teaspoons fine sea salt, more as needed",
+        ingredient: "fine sea salt, more as needed",
+      },
+      {
+        raw: "3/4 cup chopped cilantro, more for serving",
+        ingredient: "chopped cilantro, more for serving",
+      },
+      {
+        raw: "Cooked rice or couscous, for serving (optional)",
+        ingredient: "cooked rice or couscous, for serving",
+
+      },
+      {
+        raw: "2 to 3 tablespoons fresh lime juice, plus wedges for serving",
+        ingredient: "fresh lime juice, plus wedges for serving",
+
+      },
+    ]
+
+    testCases.forEach(({ raw, ingredient, }) => {
+      it(`parses ${raw}`, () => {
+        const { name } = parseIngredientComponents(raw);
+        expect(name).toEqual(ingredient);
+
+      });
+    })
+  })
+
+  describe("parseIngredientsList", () => {
+    const ingredientsList = [
+      {
+        name: "3 tablespoons neutral oil, such as sunflower or canola",
+        ingredient: "neutral oil, such as sunflower or canola",
+        unit: "tablespoons",
+        quantity: "3",
+        note: "",
+      },
+      {
+        name: "1 large onion, chopped",
+        ingredient: "large onion, chopped",
+        unit: "whole",
+        quantity: "1",
+        note: "",
+      },
+      {
+        name: "2 jalapeños, seeded or not, thinly sliced",
+        ingredient: "jalapeños, seeded or not, thinly sliced",
+        unit: "whole",
+        quantity: "2",
+        note: "",
+      },
+      {
+        name: "1 bay leaf",
+        ingredient: "bay leaf",
+        unit: "whole",
+        quantity: "1",
+        note: "",
+      },
+      {
+        name: "1 knob ginger (about 1 inch), minced",
+        ingredient: "ginger, minced",
+        unit: "knob",
+        quantity: "1",
+        note: "about 1 inch",
+      },
+      {
+        name: "4 garlic cloves, minced",
+        ingredient: "garlic, minced",
+        unit: "cloves",
+        quantity: "4",
+        note: "",
+      },
+      {
+        name: "1 1/2 teaspoons garam masala",
+        ingredient: "garam masala",
+        unit: "teaspoons",
+        quantity: "1 1/2",
+        note: "",
+      },
+      {
+        name: "1 teaspoon ground cumin",
+        ingredient: "ground cumin",
+        unit: "teaspoon",
+        quantity: "1",
+        note: "",
+      },
+      {
+        name: "1/2 teaspoon ground turmeric",
+        ingredient: "ground turmeric",
+        unit: "teaspoon",
+        quantity: "1/2",
+        note: "",
+      },
+      {
+        name: "2 (15-ounce) cans chickpeas, rinsed",
+        ingredient: "chickpeas, rinsed",
+        unit: "cans",
+        quantity: "2",
+        note: "15-ounce"
+      },
+      {
+        name: "1 (13.5-ounce) can coconut milk (do not use light coconut milk)",
+        ingredient: "coconut milk",
+        unit: "can",
+        quantity: "1",
+        note: "13.5-ounce; do not use light coconut milk"
+      },
+      {
+        name: "1 (13.5-ounce) can pumpkin purée",
+        ingredient: "pumpkin purée",
+        unit: "can",
+        quantity: "1",
+        note: "13.5-ounce"
+      },
+      {
+        name: "1 1/2 teaspoons fine sea salt, more as needed",
+        ingredient: "fine sea salt, more as needed",
+        unit: "teaspoons",
+        quantity: "1 1/2",
+        note: "",
+      },
+      {
+        name: "3/4 cup chopped cilantro, more for serving",
+        ingredient: "chopped cilantro, more for serving",
+        unit: "cup",
+        quantity: "3/4",
+        note: "",
+      },
+      {
+        name: "Cooked rice or couscous, for serving (optional)",
+        ingredient: "cooked rice or couscous, for serving",
+        unit: "whole",
+        quantity: "",
+        note: "optional"
+      },
+      {
+        name: "2 to 3 tablespoons fresh lime juice, plus wedges for serving",
+        ingredient: "fresh lime juice, plus wedges for serving",
+        unit: "tablespoons",
+        quantity: "2 to 3",
+        note: "",
+      },
+    ]
+    const parsedList = parseIngredientsList(ingredientsList);
+    parsedList.forEach((parsedIngredient, i) => {
+      it(`parsed ${ingredientsList[i].name}`, () => {
+        expect(parsedIngredient.name).toEqual(ingredientsList[i].ingredient);
+        expect(parsedIngredient.unit).toEqual(ingredientsList[i].unit);
+        expect(parsedIngredient.quantity).toEqual(ingredientsList[i].quantity);
+        expect(parsedIngredient.note).toEqual(ingredientsList[i].note);
+      })
+    })
+
+  })
+})

--- a/app/recipes/recipe.parse.utils.test.ts
+++ b/app/recipes/recipe.parse.utils.test.ts
@@ -1,5 +1,5 @@
-import { _testing, parseIngredientsList } from "./recipe.parse.utils";
-const { parseIngredientQuantity, parseIngredientNotes, parseIngredientUnit, parseIngredientComponents } = _testing;
+import { _testing } from "./recipe.parse.utils";
+const { parseIngredientQuantity, parseIngredientNotes, parseIngredientUnit, parseIngredientComponents, parseIngredientsList } = _testing;
 describe("RecipeParseUtils", () => {
 
   describe("parseIngredientQuantity", () => {
@@ -77,9 +77,7 @@ describe("RecipeParseUtils", () => {
     })
   })
 
-
-
-  describe("parseIngredients", () => {
+  describe("parseIngredientsComponents", () => {
     const testCases = [
       {
         raw: "3 tablespoons neutral oil, such as sunflower or canola",
@@ -147,7 +145,6 @@ describe("RecipeParseUtils", () => {
       {
         raw: "2 to 3 tablespoons fresh lime juice, plus wedges for serving",
         ingredient: "fresh lime juice, plus wedges for serving",
-
       },
     ]
 

--- a/app/recipes/recipe.parse.utils.ts
+++ b/app/recipes/recipe.parse.utils.ts
@@ -9,12 +9,10 @@ const COOKING_UNITS = new Set([
 /** Takes a list of ingredients which at least have a name property and return the pieces */
 export function parseIngredientsList(ingredientList: { name: string; }[]): Pick<RecipeIngredient, "name" | "note" | "quantity" | "rawIngredient" | "unit">[] {
   const parsedIngredients = [];
-
   for (const ingredient of ingredientList) {
     const parsedIngredient = parseIngredientComponents(ingredient.name);
     parsedIngredients.push({ ...parsedIngredient, rawIngredient: ingredient.name });
   }
-
   return parsedIngredients;
 };
 
@@ -27,9 +25,9 @@ function parseIngredientComponents(raw: string): Pick<RecipeIngredient, "name" |
   const strippedParensFromRaw = removeTextInParentheses(raw.toLowerCase());
 
   // Removes the quantity and unit from the raw string and also removes extra spaces
-  const ingredient = removeExtraSpaces(strippedParensFromRaw.replace(quantity, "").replace(unit, ""));
+  const ingredientName = removeExtraSpaces(strippedParensFromRaw.replace(quantity, "").replace(unit, ""));
 
-  return { quantity, unit, name: ingredient, note };
+  return { quantity, unit, name: ingredientName, note };
 }
 
 /**

--- a/app/recipes/recipe.parse.utils.ts
+++ b/app/recipes/recipe.parse.utils.ts
@@ -1,0 +1,156 @@
+import { RecipeIngredient } from "@prisma/client";
+
+const COOKING_UNITS = new Set([
+  'can', 'clove', 'cup', 'cup ', 'fl oz', 'fluid ounce', 'gal', 'gallon', 'knob', 'lb', 'ounce', 'oz', 'pint ', 'pound', 'pt', 'qt', 'quart', 'tablespoon', 'tablespoon', 'tb', 'tbsp', 'tbsp', 'teaspoon', 'teaspoon', 'tsp', 'tsp', 'whole'
+]);
+
+/** Takes a list of ingredients which at least have a name property and return the pieces */
+export function parseIngredientsList(ingredientList: { name: string; }[]): Pick<RecipeIngredient, "name" | "note" | "quantity" | "rawIngredient" | "unit">[] {
+  const parsedIngredients = [];
+
+  for (const ingredient of ingredientList) {
+    const parsedIngredient = parseIngredientComponents(ingredient.name);
+    parsedIngredients.push({ ...parsedIngredient, rawIngredient: ingredient.name });
+  }
+
+  return parsedIngredients;
+};
+
+function parseIngredientComponents(raw: string): Pick<RecipeIngredient, "name" | "note" | "quantity" | "unit"> {
+  const quantity = parseIngredientQuantity(raw);
+  const unit = parseIngredientUnit(raw);
+  const note = parseIngredientNotes(raw);
+
+  // Removes notes and the parentheses around them.
+  const strippedParensFromRaw = removeTextInParentheses(raw.toLowerCase());
+
+  // Removes the quantity and unit from the raw string and also removes extra spaces
+  const ingredient = removeExtraSpaces(strippedParensFromRaw.replace(quantity, "").replace(unit, ""));
+
+  return { quantity, unit, name: ingredient, note };
+}
+
+/**
+ * Explaining the Quantity Pattern (gpt-4):
+ *
+ * **Fraction Matcher:**
+ * Matches a single fraction like 1/2.
+ * \b\d+\/\d+\b
+ * \b is a word boundary, \d+ matches one or more digits, \/ matches the slash, and \d+ matches one or more digits after the slash.
+ *
+ * **Fraction Range Matcher:**
+ * Matches a range of fractions like 1/2 - 3/4 or 1/2 to 3/4.
+ * (?:\s*-\s*\d+\/\d+|\s*to\s*\d+\/\d+)?
+ * A non-capturing group (?: ... ) that optionally matches a hyphen or to followed by another fraction, allowing spaces around the hyphen or to.
+ *
+ * **Whole Number Matcher:**
+ * Matches a single whole number like 2.
+ * \b\d+\b
+ * Similar to the fraction matcher but without the slash and second set of digits.
+ *
+ * **Whole Number Range Matcher:**
+ * Matches a range of whole numbers like 2 - 3 or 2 to 3.
+ * (?:\s*-\s*\d+|\s*to\s*\d+)?
+ * Similar to the fraction range matcher but matches whole numbers instead of fractions.
+ *
+ * **Flags:**
+ * /g: The global flag, meaning the pattern will be tested against all possible matches in the string, not just the first one.
+ *
+ * @example "1" --> "1"
+ * @example "1/2" --> "1/2"
+ * @example "1/2 - 3/4" --> "1/2 - 3/4"
+ * @example "1/2 to 3/4" --> "1/2 to 3/4"
+ * @example "1/2 (and 1.5 here)" --> "1/2"
+ * @example "2 to 3" --> "2 to 3"
+ * @example "1 1/2" --> "1 1/2"
+ */
+function parseIngredientQuantity(raw: string): string {
+  const combinedWholeFractionMatcher = '\\b\\d+ \\d+\\/\\d+\\b';
+  const combinedWholeFractionRangeMatcher = '(?:\\s*-\\s*\\d+ \\d+\\/\\d+|\\s*to\\s*\\d+ \\d+\\/\\d+)?';
+  const fractionMatcher = '\\b\\d+\\/\\d+\\b';
+  const fractionRangeMatcher = '(?:\\s*-\\s*\\d+\\/\\d+|\\s*to\\s*\\d+\\/\\d+)?';
+  const wholeNumberMatcher = '\\b\\d+\\b';
+  const wholeNumberRangeMatcher = '(?:\\s*-\\s*\\d+|\\s*to\\s*\\d+)?';
+
+  const quantityPattern = new RegExp(
+    `${combinedWholeFractionMatcher}${combinedWholeFractionRangeMatcher}|${fractionMatcher}${fractionRangeMatcher}|${wholeNumberMatcher}${wholeNumberRangeMatcher}`,
+    'g'
+  );
+
+  const strippedParensFromRaw = removeTextInParentheses(raw.toLowerCase());
+
+  const match = RegExp(quantityPattern).exec(strippedParensFromRaw);
+  return match ? match.join(' ') : "";
+}
+
+/**
+ * Explaining the Notes Pattern (gpt-4):
+ * \( and \) match the opening and closing parentheses.
+ * ([^)]+) captures the content inside the parentheses. It matches any character except a closing parenthesis ), one or more times.
+ * The g flag is used to find all matches in the string.
+ * @example "1/2 (and 1.5 here)" --> "and 1.5 here"
+ * @example "1/2 (and 1.5 here, and 2.5 here)" --> "and 1.5 here, and 2.5 here"
+ * @example "1/2 (and 1.5 here), and 2.5 here, (3.5 here), and 4.5 here)" --> "and 1.5 here; 3.5 here"
+ */
+function parseIngredientNotes(raw: string): string {
+  const regex = /\(([^)]+)\)/g;
+  let match;
+  const notes = [];
+
+  while ((match = regex.exec(raw)) !== null) {
+    notes.push(match[1].trim());
+  }
+
+  return notes.join('; ');
+}
+
+/**
+ * A simple function to remove text in parentheses from a string.
+ * @example "1/2 (and 1.5 here)" --> "1/2"
+ * @example "1/2 (and 1.5 here), and 2.5 here" --> "1/2 , and 2.5 here"
+ */
+function removeTextInParentheses(raw: string) {
+  return raw.replace(/\([^)]*\)/g, '');
+}
+
+function removeExtraSpaces(raw: string) {
+  // Remove spaces before punctuation
+  raw = raw.replace(/\s+([,.!?;:])/, '$1');
+
+  // Remove spaces after punctuation if it's not followed by a letter or number
+  raw = raw.replace(/([,.!?;:])\s+(?![a-zA-Z0-9])/, '$1');
+
+  // Replace multiple spaces with a single space
+  raw = raw.replace(/\s{2,}/g, ' ');
+
+  return raw.trim();
+}
+
+/**
+ * The parseIngredientUnit function is actually more straight forward.
+ * We take the raw string, convert it to lowercase, and remove any text in parentheses.
+ * Then we use a regular expression to match the unit, and return the first match.
+ * If there is no match, we return the string "whole".
+ * @example "3 tablespoons neutral oil, such as sunflower or canola" --> "tablespoons"
+ * @example "1 large onion, chopped" --> "whole"
+ * @example "2 jalapeños, seeded or not, thinly sliced" --> "whole"
+ */
+function parseIngredientUnit(raw: string): string {
+  // The text in parentheses are often notes, so we remove them.
+  const strippedParensFromRaw = removeTextInParentheses(raw.toLowerCase());
+
+  const unitPatternInput = [...COOKING_UNITS.values()].map(unit => `${unit}s?`).join('|')
+  const unitPattern = new RegExp(`\\b(${unitPatternInput})\\b`, 'i');
+
+  const unitMatch = RegExp(unitPattern).exec(strippedParensFromRaw);
+  const unit = unitMatch ? unitMatch[1] : "whole";
+  return unit;
+}
+
+export const _testing = {
+  parseIngredientQuantity,
+  parseIngredientComponents,
+  parseIngredientNotes,
+  parseIngredientUnit,
+  parseIngredientsList,
+}

--- a/app/recipes/recipe.parse.utils.ts
+++ b/app/recipes/recipe.parse.utils.ts
@@ -1,5 +1,7 @@
 import { RecipeIngredient } from "@prisma/client";
 
+import { removeExtraSpaces, removeTextInParentheses } from "~/utils/strings";
+
 const COOKING_UNITS = new Set([
   'can', 'clove', 'cup', 'cup ', 'fl oz', 'fluid ounce', 'gal', 'gallon', 'knob', 'lb', 'ounce', 'oz', 'pint ', 'pound', 'pt', 'qt', 'quart', 'tablespoon', 'tablespoon', 'tb', 'tbsp', 'tbsp', 'teaspoon', 'teaspoon', 'tsp', 'tsp', 'whole'
 ]);
@@ -102,28 +104,6 @@ function parseIngredientNotes(raw: string): string {
   }
 
   return notes.join('; ');
-}
-
-/**
- * A simple function to remove text in parentheses from a string.
- * @example "1/2 (and 1.5 here)" --> "1/2"
- * @example "1/2 (and 1.5 here), and 2.5 here" --> "1/2 , and 2.5 here"
- */
-function removeTextInParentheses(raw: string) {
-  return raw.replace(/\([^)]*\)/g, '');
-}
-
-function removeExtraSpaces(raw: string) {
-  // Remove spaces before punctuation
-  raw = raw.replace(/\s+([,.!?;:])/, '$1');
-
-  // Remove spaces after punctuation if it's not followed by a letter or number
-  raw = raw.replace(/([,.!?;:])\s+(?![a-zA-Z0-9])/, '$1');
-
-  // Replace multiple spaces with a single space
-  raw = raw.replace(/\s{2,}/g, ' ');
-
-  return raw.trim();
 }
 
 /**

--- a/app/recipes/recipe.server.ts
+++ b/app/recipes/recipe.server.ts
@@ -75,9 +75,8 @@ export async function getRecipeDetails({ id }: Pick<Recipe, "id">) {
   });
 }
 
-export interface RecipeUserArgs extends Pick<Recipe, "id"> { requestingUser?: Partial<Pick<User, "id">> }
 
-export async function getRecipeWithIngredients({ id, requestingUser }: RecipeUserArgs) {
+export async function getRecipeWithIngredients(id: Recipe["id"], requestingUserId?: User["id"]) {
   const recipe = await prisma.recipe.findFirst({
     select: {
       id: true,
@@ -117,7 +116,7 @@ export async function getRecipeWithIngredients({ id, requestingUser }: RecipeUse
 
   });
   if (!recipe) return null;
-  if (recipe.isPrivate && requestingUser?.id !== recipe.submittedBy) return null;
+  if (recipe.isPrivate && requestingUserId !== recipe.submittedBy) return null;
   return recipe;
 }
 
@@ -147,7 +146,7 @@ export async function deleteRecipeComment(recipeId: Recipe["id"], commentId: Com
   });
 };
 
-export async function getRecipeComments({ id, requestingUser }: RecipeUserArgs): Promise<FlatCommentServer[]> {
+export async function getRecipeComments( id: Recipe["id"], requestingUserId?: User["id"]): Promise<FlatCommentServer[]> {
   const recipeComments = await prisma.recipeComment.findMany({
     select: {
       comment: {
@@ -175,7 +174,7 @@ export async function getRecipeComments({ id, requestingUser }: RecipeUserArgs):
   const commentType: CommentTypes = "recipe";
   return recipeComments
     .map(({ comment }) => ({ ...comment }))
-    .filter(c => filterPrivateComments(c, requestingUser?.id ?? ""))
+    .filter(c => filterPrivateComments(c, requestingUserId ?? ""))
     .map((c) => flattenAndAssociateComment(c, { associatedId: id, commentType }))
 }
 

--- a/app/recipes/recipes.$recipeId.route.tsx
+++ b/app/recipes/recipes.$recipeId.route.tsx
@@ -82,7 +82,7 @@ export default function RecipeDetailsPage() {
       {isUsersRecipe ? (
         <div className="flex justify-between gap-4 flex-col lg:flex-row">
           <h2 className="text-4xl font-bold">{data.recipe.title}</h2>
-          <div className="flex flex-col gap-2 justify-between sm:flex-row">
+          <div className="flex flex-col-reverse gap-2 justify-between sm:flex-row">
             <Form method="post" className="flex flex-col gap-2 sm:flex-row">
               <button
                 type="submit"

--- a/app/recipes/recipes.$recipeId.route.tsx
+++ b/app/recipes/recipes.$recipeId.route.tsx
@@ -130,7 +130,7 @@ export default function RecipeDetailsPage() {
       <List title="Steps" items={data.recipe.preparationSteps} ListType="ol" />
       <CollapsibleSection title="Additional Detail">
         <p className="pb-2">Source: {data.recipe.source || "User Submitted"}</p>
-        <p className="pb-2 flex items-center">
+        <p className="pb-2 flex items-center max-w-screen-sm">
           URL:&nbsp;
           {data.recipe.sourceUrl ? (
             <TruncateText>

--- a/app/recipes/recipes.$recipeId_.cook.route.tsx
+++ b/app/recipes/recipes.$recipeId_.cook.route.tsx
@@ -7,6 +7,7 @@ import {
 } from "@remix-run/react";
 import { redirect } from "react-router";
 
+import { CreateCommentForm } from "~/comments/api.comments.route";
 import { Checklist } from "~/components/checklist";
 import { CollapsibleSection } from "~/components/collapsible";
 import { List } from "~/components/lists";
@@ -147,6 +148,12 @@ export default function RecipeCookPage() {
       </CollapsibleSection>
       <CollapsibleSection title={"Steps"}>
         <Checklist items={data.recipe.preparationSteps} />
+      </CollapsibleSection>
+      <CollapsibleSection title={"Cooking Notes"}>
+        <CreateCommentForm
+          commentType={"recipe"}
+          associatedId={data.recipe.id}
+        />
       </CollapsibleSection>
     </div>
   );

--- a/app/recipes/recipes._index.route.tsx
+++ b/app/recipes/recipes._index.route.tsx
@@ -4,7 +4,7 @@ export default function RecipeIndexPage() {
   return (
     <p>
       No note selected. Select a note on the left, or{" "}
-      <Link to="new" className="text-blue-500 underline">
+      <Link to="new?submissionStyle=create-from-url" className="text-blue-500 underline">
         create a new recipe.
       </Link>
     </p>

--- a/app/recipes/recipes.route.tsx
+++ b/app/recipes/recipes.route.tsx
@@ -39,7 +39,7 @@ export default function RecipesPage() {
       <main className="flex flex-col-reverse md:flex-row">
         <div className="max-h-screen overflow-scroll border-r bg-blue-50 w-full md:min-w-200 md:w-80 ">
           <Link
-            to="new?submissionStyle=create-manual"
+            to="new?submissionStyle=create-from-url"
             className="
           block p-4 text-xl text-blue-500
           hover:bg-blue-600 active:bg-blue-400 focus:bg-blue-700 hover:text-white

--- a/app/utils/strings.test.ts
+++ b/app/utils/strings.test.ts
@@ -1,6 +1,6 @@
-import { isValidString } from "./strings";
+import { isValidString, removeExtraSpaces, removeTextInParentheses } from "./strings";
 
-describe ("isValidString", () => {
+describe("isValidString", () => {
   test("isValidString returns false for null", () => {
     const nullValue = null as unknown as string;
     expect(isValidString(nullValue)).toBe(false)
@@ -17,4 +17,19 @@ describe ("isValidString", () => {
   test("isValidString returns false for whitespace strings", () => {
     expect(isValidString(" ")).toBe(false)
   })
+})
+
+describe("removeTextInParentheses", () => {
+  test("removeTextInParentheses removes parenthesis and inside text", () => {
+    const text = '1/2 (and 1.5 here)'
+    expect(removeTextInParentheses(text)).toBe('1/2 ')
+  })
+})
+
+describe("removeExtraSpaces", () => {
+  test("removeExtraSpaces removes spaces before punctuation", () => {
+    const text = ' 1/2  ,  and 2.5 here. '
+    expect(removeExtraSpaces(text)).toBe('1/2, and 2.5 here.')
+  }
+  )
 })

--- a/app/utils/strings.ts
+++ b/app/utils/strings.ts
@@ -1,1 +1,27 @@
 export const isValidString = (str: unknown): str is string => typeof str == 'string' && str.trim().length > 0
+
+/**
+ * A simple function to remove text in parentheses from a string.
+ * @example "1/2 (and 1.5 here)" --> "1/2"
+ * @example "1/2 (and 1.5 here), and 2.5 here" --> "1/2 , and 2.5 here"
+ */
+export const removeTextInParentheses = (raw: string) => {
+  return raw.replace(/\([^)]*\)/g, '');
+}
+
+/**
+ * A function to remove extra spaces from a string.
+ * @example " 1/2  ,  and 2.5 here. " --> "1/2, and 2.5 here."
+ */
+export const removeExtraSpaces = (raw: string) => {
+  // Remove spaces before punctuation
+  raw = raw.replace(/\s+([,.!?;:])/, '$1');
+
+  // Remove spaces after punctuation if it's not followed by a letter or number
+  raw = raw.replace(/([,.!?;:])\s+(?![a-zA-Z0-9])/, '$1');
+
+  // Replace multiple spaces with a single space
+  raw = raw.replace(/\s{2,}/g, ' ');
+
+  return raw.trim();
+}

--- a/prisma/migrations/20231231001601_1703981761/migration.sql
+++ b/prisma/migrations/20231231001601_1703981761/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "recipe_ingredients" ADD COLUMN "rawIngredient" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -141,15 +141,16 @@ model Menu {
 }
 
 model RecipeIngredient {
-  recipeId    String // Foreign key for Recipe
-  id          String    @id @default(uuid())
-  name        String
-  quantity    String?
-  unit        String?
-  note        String?
-  createdDate DateTime? @default(now()) @map("created_date")
-  updatedDate DateTime? @default(now()) @map("updated_date")
-  recipe      Recipe    @relation(fields: [recipeId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+  recipeId      String // Foreign key for Recipe
+  id            String    @id @default(uuid())
+  name          String
+  quantity      String?
+  unit          String?
+  note          String?
+  rawIngredient String? // When imported, this is what was originally surfaced in the recipe before parsing
+  createdDate   DateTime? @default(now()) @map("created_date")
+  updatedDate   DateTime? @default(now()) @map("updated_date")
+  recipe        Recipe    @relation(fields: [recipeId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 
   @@index([name], name: "recipe_ingredients_name")
   @@map("recipe_ingredients")


### PR DESCRIPTION
This PR focuses primarily on fixing the NYTimes parsing. 

There are also a few other things:
1. Adding notes to the /cook page
2. Simplifying APIs, extracting utils
3. Adding test coverage.